### PR TITLE
Make flake8 max line length equal to 88

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -20,4 +20,4 @@ jobs:
         pip install flake8
     - name: Linting the code with flake8
       run: |
-        flake8 --max-line-length 88 $(git ls-files '*.py')
+        flake8 $(git ls-files '*.py')

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 88


### PR DESCRIPTION
``flake8`` has stricter line length requirements than ``black``. This PR makes them consistent.

In order to avoid duplication of settings (in CI and setup.cfg), the option
is removed from ``flake8`` invocation in the CI job.

This change should also make the setting consistent for people who do not use
pre-commit hooks.