### PR TITLE
Simple Adder updates

### DIFF
--- a/examples/first_job_on_AML/src/sim.py
+++ b/examples/first_job_on_AML/src/sim.py
@@ -29,10 +29,7 @@ class SimpleAdder(Env):
 
     def _get_obs(self):
         """Get the observable state."""
-        return {
-            key: np.array([self.state[key]])
-            for key in self.observation_space.spaces.keys()
-        }
+        return {"value": np.array([self.state["value"]])}
 
     def _get_info(self):
         """Get additional info not needed by the agent's decision."""


### PR DESCRIPTION
Updated the sim.py with the following changes:

- observation_space and action_space are now of type Spaces.Dict
- self.state dictionary is introduced
- reward method doesn't require inputs
- inital value is initialized at random between 0 and 100
- early termination when the target value of 50 is achieved
- terminated and truncated are differentiated in accordance with Gymnasium docs
- _get_obs automatically get required state values from self.state dictionary