### PR TITLE
Build docs automatically using GH actions

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -1,0 +1,15 @@
+name: build-docs
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - run: pip install mkdocs
+      - run: mkdocs gh-deploy --force --clean --verbose

--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ guidelines:
 -	PR can contain more commits, but it is always better to have one PR for one commit
 -	PR should have a clear description of why the change is made and why it is made in a particular way
 
+### Building the docs
+
+Docs are built automatically using ``mkdocs`` whenever a change lands to
+main.
+
 ## Trademarks
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft


### PR DESCRIPTION
# Description

This PR adds a CI job for building docs at each change that lands into main.

## Why the URL looks strange?

This is because we set GH pages to private. If we write URLs on
https://Azure.github.io/plato/ we still point to the correct
place in the docs but the URL is set to some seemingly random name.
For instance, check that the following points to the right section:
https://azure.github.io/plato/user_guides

We could start adding links to samples using the azure.plato... address.

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?

Check docs are visible at https://Azure.github.io/plato/
