### PR TITLE
Fix the way mypy reconstructs packages when scanning

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -20,4 +20,4 @@ jobs:
         pip install -r requirements/dev_requirements.txt
     - name: Analysing code with mypy
       run: |
-        mypy $(git ls-files '*.py')
+        mypy --explicit-package-bases $(git ls-files '*.py')


### PR DESCRIPTION
This commit fixes the way ``mypy`` reconstructs packages when scanning the repository for errors.
Currently, we might have python files in samples with the same name. According to my understanding, when no ``__init__.py`` is present in the same folder, ``mypy`` is not able to define unique fully qualified module names. For instance, imagine we have two samples with:

examples/sample1/src/main.py
examples/sample2/src/main.py

``mypy`` will error out with the following message:

```
examples/sample1/src/main.py: error: Duplicate module named "main" (also at "examples/sample2/src/main.py")
```

By adding the ``--explicit-package-bases``, ``mypy`` defines the fully qualified module name even when no ``__init__.py`` is present in the folder.

Details at: https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-paths-to-modules