### PR TITLE
update docs links in readme and add sim info to simple adder sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Plato is a Python toolkit that enables users to train reinforcement learning (RL
 In addition to RL training and assessment on AML, Plato offers additional features and guidance for domain randomization, hyperparameter tuning via Ray Tune, experiment management with MLflow, and Dockerized deployment of a trained agent.
 
 ## Documentation
-* [Glossary](./plato-docs/docs/glossary.md)
+* [Glossary](https://azure.github.io/plato/glossary/)
 * Prerequisites
-    * [Create AML Resources](./docs/index.md#create-azure-resources)
-    * [AML Environment Setup](./docs/index.md#aml-environment-setup)
-    * [Custom Simulation Environment](./docs/index.md#custom-simulation-environment-with-gymnasium)
+    * [Create AML Resources](https://azure.github.io/plato/#create-azure-resources)
+    * [AML Environment Setup](https://azure.github.io/plato/#aml-environment-setup)
+    * [Custom Simulation Environment](https://azure.github.io/plato/#custom-simulation-environment-with-gymnasium)
 * Samples
     * [Simple Adder](https://github.com/Azure/plato/tree/main/examples/first_job_on_AML):  A minimal working example of a Python simulation environment that can be connected to RLlib and used to train an agent on AML. You can think of it as a "Hello World" sample.
 * User Guides

--- a/examples/first_job_on_AML/README.md
+++ b/examples/first_job_on_AML/README.md
@@ -5,45 +5,50 @@ with a custom Gymnasium environment.
 
 ### What this sample covers
 
-- How to integrate a custom Gymnasium environment with RLlib
-- How to train an agent using that environment on AML
+- Integration of a custom Gymnasium simulation environment with RLlib
+- How to train an agent using the simulation environment on AML
 
 ### What this sample does not cover
 
 - How to optimize the training algorithm for best performance
 - How to visualize the performance of the agent
 - How to evaluate the agent
-- How to deploy the trained agent
+- How to deploy the agent
 
 ## Prerequisites
 
-- Install the Azure CLI and the ML extension
-- Create an AML workspace
-- Create a compute cluster in your AML workspace
-- Create an AML environment using the conda file provided: ``conda.yml`` by
-  running the following command:
+- Install the Azure CLI on your machine:
+```
+pip install azure-cli
+```
+- Add the ML extension:
+```
+az extension add -n ml
+```
+- [Create an AML workspace and compute cluster](https://azure.github.io/plato/#create-azure-resources)
+- Create an AML environment using the conda file provided ``conda.yml``:
 ```bash
 az ml environment create --name aml-environment --conda-file conda.yml --image mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04 --resource-group $YOUR_RESOURCE_GROUP --workspace-name $YOUR_WORKSPACE
 ```
 
+## What is being "simulated"?
+The simulation in this sample (`./scr/sim.py`) is intentionally very simple. During an episode, at each step, the simulation adds the action ("addend") to its state "value". Note that addend can be negative, which will cause value to decrease.
+
+During training, the agent learns to adjust the addend action to achieve a state value of 50.
+
 ## Run the experiment
 
-To run the experiment, you can use the included ``job.yml``. The file
-defines all parameters needed to successfully launch the job. Please
-remember to change the name of the ``environment`` and ``compute`` to be the
+1. Modify the ``job.yml`` file by changing the name of the ``environment`` and ``compute`` to be the
 same as those you created in the prerequisites section.
 
-Launch the job using the Azure CLI, for instance with
-```bash
+2. Launch the job using the Azure CLI:
+```
 az ml job create -f job.yml --workspace-name $YOUR_WORKSPACE --resource-group $YOUR_RESOURCE_GROUP
 ```
 
-## Check that it runs
+3. Check that it is running by finding the job you launched in [AML studio](https://ml.azure.com/). You should see that ``ray`` is writing logs in the *Outputs + logs* tab in the ``user_logs`` folder.
 
-Find the job you launched in the Azure UI. You should see that ``ray`` is
-writing logs in the *Outputs + logs* tab in the ``user_logs`` folder.
+4. Once the job is completed, the model checkpoints can be found in [AML studio](https://ml.azure.com/) under the *Outputs + Logs* tab of your job in the ``outputs`` folder.
 
-## Trained agent
-
-Once the training is completed, the model checkpoints can be found in AML
-Studio under the *Outputs + Logs* tab of your job in the ``outputs`` folder.
+## Next Steps
+Congratulations! You've trained your first agent at scale on Azure. Now that you understand the basics of running an experiment, try our more advanced examples that show you how to modify your algorithm and evaluate/deploy a trained agent.


### PR DESCRIPTION
# Description

Modified the links in the root readme to point to our new GH pages. Also modified the simple adder sample (first_job_on_aml) readme to have a little more info on the sim itself, plus a few changes to the format.

## Type of change

- [x] This change is a documentation update

# Checklist:

- [x] I have squashed my previous commits into one commit and added a __meaningful__ commit message.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
