### PR TITLE
Add scenario config and domain randomization to simple adder

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,6 +5,7 @@ AML.
 
 We suggest going through the samples in the following order:
 
-1. ``getting-started-on-aml``: learn how train your first RL agent on AML
-2. ``hyperparameter-tuning-and-monitoring``: learn how to use `mlflow` and `ray.tune` to save model checkpoints and tune hyperparameters.
+1. ``getting-started-on-aml``: learn how to train your first RL agent on AML
+2. ``hyperparameter-tuning-and-monitoring``: learn how to use `mlflow` and
+   `ray.tune` to save model checkpoints and tune hyperparameters.
 3. ``deploy-agent``: learn how to deploy an agent locally or with docker

--- a/examples/getting-started-on-aml/README.md
+++ b/examples/getting-started-on-aml/README.md
@@ -7,6 +7,7 @@ with a custom Gymnasium environment.
 
 - Integration of a custom Gymnasium simulation environment with RLlib
 - How to train an agent using the simulation environment on AML
+- How to do domain randomization
 
 ### What this sample does not cover
 
@@ -32,6 +33,7 @@ az ml environment create --name aml-environment --conda-file conda.yml --image m
 ```
 
 ## What is being "simulated"?
+
 The simulation in this sample (`./scr/sim.py`) is intentionally very simple.
 During an episode, at each step, the simulation adds the action ("addend") to
 its state "value". Note that addend can be negative, which will cause value
@@ -39,6 +41,15 @@ to decrease.
 
 During training, the agent learns to adjust the addend action to achieve a
 state value of 50.
+
+
+## Domain randomization
+
+Domain randomization is the technique of modifying the initial conditions of
+the system in order to let the agent experience the most important parts of
+the parameter space.
+In this example we apply domain randomization by passing a custom range of
+initial values to the simulation environment.
 
 ## Run the experiment
 
@@ -72,6 +83,7 @@ az ml job create -f job.yml --workspace-name $YOUR_WORKSPACE --resource-group $Y
    in the ``outputs`` folder.
 
 ## Next Steps
+
 Congratulations! You've trained your first agent at scale on Azure. Now that
 you understand the basics of running an experiment, try our more advanced
 examples that show you how to modify your algorithm and evaluate/deploy a

--- a/examples/getting-started-on-aml/src/main.py
+++ b/examples/getting-started-on-aml/src/main.py
@@ -16,6 +16,15 @@ from sim import SimpleAdder as SimEnv
 # Register the simulation as an RLlib environment.
 register_env("sim_env", lambda config: SimEnv(config))
 
+# Domain Randomization:
+# Provide allowed initial values for the simple adder
+# This will be passed as env_config to the sim environment
+config = {
+    "values": range(-10, 10),
+    # Customize maximum episode duration
+    "max_steps": 10,
+}
+
 
 def train(local=False):
     # Define the algo for training the agent
@@ -27,7 +36,8 @@ def train(local=False):
         .resources(num_gpus=0)
         # Set the training batch size to the appropriate number of steps
         .training(train_batch_size=4_000)
-        .environment(env="sim_env")
+        # config is passed to apply domain randomization
+        .environment(env="sim_env", env_config=config)
         .build()
     )
     # Train for 10 iterations

--- a/examples/getting-started-on-aml/src/sim.py
+++ b/examples/getting-started-on-aml/src/sim.py
@@ -1,4 +1,6 @@
 """Implementation of a simple simulation/environment in AML."""
+from random import choice
+
 import numpy as np
 from gymnasium import Env
 from gymnasium.spaces import Box, Dict
@@ -13,19 +15,55 @@ class SimpleAdder(Env):
 
     The environment has a pretty simple state and action space. The state is
     composed of an integer numbers. The action is composed of an integer number
-    between -10 and 10. At each episode, the state number is initialized between
-    0 and 100, and at each iteration the agent chooses a number between -10 and 10.
-    The chosen number is added to the state. The purpose of the simulation is to
-    get the state equal to 50, at which point the episode terminates. The episode
-    duration is limited to 10 iterations.
+    between -10 and 10.
+
+    At each episode, the state number is initialized between 0 and 100. The
+    range of possible initial values can be overwritten by passing an iterable
+    to ``env_config``. This capability can be used to apply domain
+    randomization to the training process.
+
+    At each iteration, the agent chooses a number between -10 and 10. The
+    chosen number is added to the state. The purpose of the simulation is to
+    get the state equal to 50, at which point the episode terminates. The
+    maximum episode duration can be configured via ``env_config``. The default
+    duration is 10 steps.
     """
 
     def __init__(self, env_config):
         self.observation_space = Dict(
-            {"value": Box(low=-float("inf"), high=float("inf"))}
+            {"value": Box(low=-float("-inf"), high=float("inf"), dtype=int)}
         )
-        self.action_space = Dict({"addend": Box(low=-10, high=10, dtype=np.int32)})
-        self.state = {"value": 0}
+        self.action_space = Dict({"addend": Box(low=-10, high=10, dtype=int)})
+        self.initial_values = self.set_initial_values(env_config.get("values"))
+        self.max_steps = env_config.get("max_steps", 10)
+        self.state = {"value": self.get_initial_value()}
+
+    def set_initial_values(self, values):
+        """
+        Set the allowed initial values for the sim environment.
+
+        This function is used for domain randomization.
+        If the user does not pass the set of allowed initial values, the sim
+        environment takes the default range.
+
+        It's important the function checks that the provided initial
+        values are contained in observation_space.
+        If they're not, it raises a ValueError.
+        """
+        if values is None:
+            values = range(0, 101)
+        for value in values:
+            if not self.observation_space.get("value").contains([value]):
+                raise ValueError(
+                    "The initial value provided is not contained"
+                    " in the allowed values."
+                    f" Found {value}."
+                )
+        return values
+
+    def get_initial_value(self):
+        """Pick the initial value from the set of possible values."""
+        return choice(self.initial_values)
 
     def _get_obs(self):
         """Get the observable state."""
@@ -45,7 +83,7 @@ class SimpleAdder(Env):
 
     def reset(self, *, seed=None, options=None):
         """Start a new episode."""
-        self.state = {"value": np.random.randint(0, 100)}
+        self.state = {"value": self.get_initial_value()}
         self.iter = 0
         return self._get_obs(), self._get_info()
 
@@ -55,7 +93,7 @@ class SimpleAdder(Env):
         self.iter += 1
         reward = self.reward(self.state)
         terminated = self.state["value"] == 50
-        truncated = self.iter >= 10
+        truncated = self.iter >= self.max_steps
         return (
             self._get_obs(),
             reward,


### PR DESCRIPTION
# Description

Information is added to the getting started sample to show users how one can
define the initial value of the simulation parameters.
This allows one to do domain randomization.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update (maybe explain what domain randomization is?)

# How Has This Been Tested?

Run the sample locally by modifying the value in ``config`` in ``main.py``.

# Checklist:

- [x] I have squashed my previous commits into one commit and added a __meaningful__ commit message.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
