### PR TITLE
standardize readme files across examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ In addition to RL training and assessment on AML, Plato offers additional featur
     * [Create AML Resources](https://azure.github.io/plato/#create-azure-resources)
     * [AML Environment Setup](https://azure.github.io/plato/#aml-environment-setup)
     * [Custom Simulation Environment](https://azure.github.io/plato/#custom-simulation-environment-with-gymnasium)
-* Samples
-    * [Simple Adder](https://github.com/Azure/plato/tree/main/examples/getting-started-on-aml):  A minimal working example of a Python simulation environment that can be connected to RLlib and used to train an agent on AML. You can think of it as a "Hello World" sample.
-* User Guides
+* Examples
+    * [Getting Started on AML](https://github.com/Azure/plato/tree/main/examples/getting-started-on-aml):  A minimal working example of a Python simulation environment that can be connected to RLlib and used to train an agent on AML. You can think of it as a "Hello World" example.
+    * [Hyperparameter Tuning and Monitoring](https://github.com/Azure/plato/tree/main/examples/hyperparameter-tuning-and-monitoring): Learn how to tune, monitor, and download agents on AML.
+    * [Deploy Agent](https://github.com/Azure/plato/tree/main/examples/deploy-agent): Serve your agent locally or package and deploy it on Azure.
 
 ## Contributing
 

--- a/examples/deploy-agent/README.md
+++ b/examples/deploy-agent/README.md
@@ -1,7 +1,18 @@
-# Deploy a trained agent
+# Deploy a Trained Agent
 
 This sample shows how to deploy a trained agent using ``ray``'s module
 ``serve``.
+
+### What this sample covers
+
+- How to serve the agent locally
+- How to package and deploy the agent with Docker
+
+### What this sample does not cover
+
+- How to train the agent
+- How to visualize the performance of the agent
+- How to evaluate the agent
 
 ## Prerequisites
 
@@ -12,73 +23,59 @@ This sample shows how to deploy a trained agent using ``ray``'s module
 
 ## Tutorial
 
-### Step 1: Download the checkpoints locally
+1. Download the checkpoints locally to the ``checkpoints`` folder.
 
-Download the model checkpoints to the ``checkpoints`` folder.
+2. Modify the deployment script at ``src/serve.py``. Please adapt the script to your setup as follows:
+    - Change the variable ``CHECKPOINT_FOLDER`` to the name of the folder containing your RLlib checkpoints.
+    - Please note that ``CHECKPOINT_FOLDER`` must be the name of the folder inside ``checkpoints`` that contains the trained agent.
+    - Modify the `observation_space` and `action_space` variables to be the same as in your simulation environment used for training the agent.
 
-### Step 2: Modify the deployment script
+3. Change package versions in `requirements.txt` to match your training environment.
+    - For example, if your training environment has ray==2.3.0 and this file has ray==2.4.0, you need to change it to ray==2.3.0.
 
-You can find the deployment script at ``src/serve.py``.
-Please adapt the script to your setup as follows:
+4. Test locally:
+    - Install the required dependencies:
 
-- Change the variable ``CHECKPOINT_FOLDER`` to the name of the folder containing your RLlib checkpoints.
-  - Please note that
-``CHECKPOINT_FOLDER`` must be the name of the folder inside ``checkpoints``
-that contains the trained agent.
-- Modify the `observation_space` and `action_space` variables to be the same as in your simulation environment used for training the agent.
+    ```bash
+    pip install -r requirements.txt
+    ```
 
-### Step 3: Change package versions to align with your training environment
+    - Serve the agent locally by running the following command in the
+  ``src`` folder:
 
-The `requirements.txt` file lists the Python packages needed to deploy your agent. You need to edit the versions in this file to match your agent training environment. For example, if your training environment has ray==2.3.0 and this file has ray==2.4.0, you need to change it to ray==2.3.0.
+    ```bash
+    serve run serve:agent
+    ```
 
-### Step 4: Test locally
+    - You can now reach the agent at ``http://localhost:8000``. For example, use the
+    following snippet to get the action from the agent:
 
-First, install the required dependencies:
+    ```python
+    import requests
+    resp = requests.get('http://localhost:8000', json={'state':{'value': 5}})
+    print(resp.json)
+    ```
 
-```bash
-pip install -r requirements.txt
-```
+    - Or, try the following cURL command in your terminal:
 
-Then, test the agent locally by running the following command in the
-``src`` folder:
+    ```
+    curl --request POST --url "http://localhost:8000/" --data '{"state":{"value": 5}}'
+    ```
 
-```bash
-serve run serve:agent
-```
+5. (OPTIONAL) Package and deploy the agent locally:
+    - Use the included ``Dockerfile`` for packaging the agent. If you have Docker installed locally, build the agent by running the following command in this folder:
 
-You can reach the agent at ``http://localhost:8000``. For example, use the
-following snippet to get the action from the agent:
+    ```bash
+    docker build -t rl-agent .
+    ```
 
-```python
-import requests
-resp = requests.get('http://localhost:8000', json={'state':{'value': 5}})
-print(resp.json)
-```
+    - You can then use the image ``rl-agent`` and deploy the brain locally via docker:
 
-Or, try the following cURL command in your terminal:
+    ```bash
+    docker run -p 8000:8000 rl-agent
+    ```
 
-```
-curl --request POST --url "http://localhost:8000/" --data '{"state":{"value": 5}}'
-```
-
-### (Optional) Step 5: Package and deploy the agent locally
-
-Use the included ``Dockerfile`` for packaging the agent. If you have Docker installed locally, you can build the agent and test that
-it works.
-To build the agent run the following command in this folder
-
-```bash
-docker build -t rl-agent .
-```
-
-You can then use the image ``rl-agent`` locally and deploy the brain locally
-via docker:
-
-```bash
-docker run -p 8000:8000 rl-agent
-```
-
-To ensure that the agent responds correctly, use the same requests or cURL commands shown in Step 4 (*Test locally*).
+    - To ensure that the agent responds correctly, use the same requests or cURL commands shown in Step 4 (*Test locally*).
 
 ## Next Steps
 After you have containerized your RL agent, you can:

--- a/examples/getting-started-on-aml/README.md
+++ b/examples/getting-started-on-aml/README.md
@@ -1,7 +1,7 @@
-# Simple Adder Sample
+# Getting Started on AML
 
 In this folder we show how to get started training an RL agent on Azure ML
-with a custom Gymnasium environment.
+with a custom Gymnasium environment ("Simple Adder").
 
 ### What this sample covers
 
@@ -26,7 +26,7 @@ pip install azure-cli
 az extension add -n ml
 ```
 - [Create an AML workspace and compute cluster](https://azure.github.io/plato/#create-azure-resources)
-- Create an AML environment using the conda file provided ``conda.yml``:
+- Create an AML environment using the conda file provided: ``conda.yml`` by running the following command:
 ```bash
 az ml environment create --name aml-environment --conda-file conda.yml --image mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04 --resource-group $YOUR_RESOURCE_GROUP --workspace-name $YOUR_WORKSPACE
 ```
@@ -40,10 +40,10 @@ to decrease.
 During training, the agent learns to adjust the addend action to achieve a
 state value of 50.
 
-## Run the experiment
+## Run Locally
 
 As a preliminary step, you should check that the simulation works on your
-local machine. In this way you'll save precious development time.
+local machine to save precious development time.
 The ``main.py`` script in the ``src`` folder allows you to test locally with
 the following command:
 
@@ -51,10 +51,11 @@ the following command:
 python main.py --test-local
 ```
 
+## Tutorial: Run on AML
 After you checked that the simulation works properly, follow these steps to
 train an RL agent on AML:
 
-1. Modify the ``job.yml`` file by changing the name of the ``environment``
+1. Modify the ``job.yml`` file by changing the name of the AML ``environment``
    and ``compute`` to be the same as those you created in the prerequisites
    section.
 
@@ -67,8 +68,8 @@ az ml job create -f job.yml --workspace-name $YOUR_WORKSPACE --resource-group $Y
    studio](https://ml.azure.com/). You should see that ``ray`` is writing
    logs in the *Outputs + logs* tab in the ``user_logs`` folder.
 
-4. Once the job is completed, the model checkpoints can be found in [AML
-   studio](https://ml.azure.com/) under the *Outputs + Logs* tab of your job
+4. Once the job is completed, the model checkpoints can also be found in AML
+   studio under the *Outputs + Logs* tab of your job
    in the ``outputs`` folder.
 
 ## Next Steps

--- a/examples/hyperparameter-tuning-and-monitoring/README.md
+++ b/examples/hyperparameter-tuning-and-monitoring/README.md
@@ -2,23 +2,28 @@
 
 This folder demonstrates an example of using MLFlow to log models and data with AzureML.
 
-## How to Run
+### What this sample covers
 
-The source for running the experiment is under `src/mlflow_run.py`. The script defines a single function: `run()` which can be run locally or on AzureML using the `Ray-on-AML` library.
+- How to optimize the training algorithm for best performance
+- How to visualize the performance of the agent
 
-### Run Locally
+### What this sample does not cover
 
-You can run the script locally for testing and experimentation. The `smoke-test` option ensures each run is only for a single training iteration to save time.
+- How to evaluate the agent
+- How to deploy the agent
 
-```bash
-python mlflow_run.py --test-local --smoke-test
-```
 
 ## Prerequisites
 
-- Install the Azure CLI and the ML extension
-- Create an AML workspace
-- Create a compute cluster in your AML workspace
+- Install the Azure CLI on your machine:
+```
+pip install azure-cli
+```
+- Add the ML extension:
+```
+az extension add -n ml
+```
+- [Create an AML workspace and compute cluster](https://azure.github.io/plato/#create-azure-resources)
 - Create an AML environment using the conda file provided: ``conda.yml`` by running the following command:
 
 ```bash
@@ -27,24 +32,42 @@ az ml environment create --name ray-mlflow-env --conda-file conda.yml --image mc
 
 Note that the environment in this sample is slightly different than the previous sample, so you will need to create a new environment.
 
-## Run the Job on AML
+## What is being "simulated"?
+This example uses the classic ["CartPole-v1"](https://gymnasium.farama.org/environments/classic_control/cart_pole/) simulation environment. The example runs Ray Tune's [population based training (PBT)](https://docs.ray.io/en/latest/_modules/ray/tune/schedulers/pbt.html) to simultaneously train and optimize a group of agents - regularly testing the agents, replicating the top performers, and perturbing their hyperparameters. The MLflow integration allows logging of all artifacts produced by Ray Tune, such as the model checkpoints, to MLflow.
 
-To run the experiment, you can use the included ``job.yml``. The file
-defines all parameters needed to successfully launch the job. Please
-remember to change the name of the ``environment`` and ``compute`` to be the
-same as those you created in the prerequisites section. Please see the provided ``job.yml`` for an example.
-Note that the `environment` parameter has a prefix `azureml` and a suffix with the version, in this case `@latest`. Please refer to the [Azure Machine Learning](https://learn.microsoft.com/en-us/azure/machine-learning/reference-yaml-job-command?view=azureml-api-2) docs for more information.
+## Run Locally
+The source for running the experiment is under `src/mlflow_run.py`. The script defines a single function: `run()` which can be run locally or on AzureML.
 
-Launch the experiment using the Azure CLI and the `ml` extension:
+You can run the script locally for testing and experimentation. The `smoke-test` option ensures each run is only for a single training iteration to save time.
 
 ```bash
-az ml job create -f job.yml --workspace-name $YOUR_WORKSPACE --resource-group $YOUR_RESOURCE_GROUP
+python mlflow_run.py --test-local --smoke-test
 ```
 
-## Monitor Your Job
+## Tutorial: Run on AML
 
-After submitting your experiment using the Azure CLI and your yaml file, AML will create an experiment and spin up multiple jobs, one for each sweep over your hyperparameter space. You can monitor the jobs on the AML studio website by locating your experiment. The experiment should be listed under the display name of your `yaml` file above. If you have hyperparameter tuning enabled, you will see separate model files for each run under the *Outputs + logs*. You can also view the metrics for each job in the experiment under the *Metrics* tab.
+1. Modify the ``job.yml`` file by changing the name of the AML ``environment``
+   and ``compute`` to be the same as those you created in the prerequisites
+   section.
+    - Note that the `environment` parameter has a prefix `azureml` and a suffix with the version, in this case `@latest`. Refer to the [Azure Machine Learning](https://learn.microsoft.com/en-us/azure/machine-learning/reference-yaml-job-command?view=azureml-api-2) docs for more information.
 
-## Download Model Files for Local Testing
+2. Launch the experiment using the Azure CLI `ml` extension:
 
-Upon completion of your experiment, you can download the model files to your local machine for testing and assessment. The script `get_mlflow_artifacts.py` provides function for querying your MLFlow registry on AzureML and downloads the top performing policy to your local machine. In order to run this script, first create a [workspace configuration file](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-configure-environment?view=azureml-api-2#local-and-dsvm-only-create-a-workspace-configuration-file) in your local directory to run this script.
+    ```bash
+    az ml job create -f job.yml --workspace-name $YOUR_WORKSPACE --resource-group $YOUR_RESOURCE_GROUP
+    ```
+
+    - After submitting your experiment using the Azure CLI and your yaml file, AML will create an experiment and spin up multiple jobs, one for each sweep over your hyperparameter space.
+
+3. Monitor the jobs on the [AML studio website](https://ml.azure.com/) by locating your experiment, which is listed under the display name of your `job.yml` file above.
+    - If you have hyperparameter tuning enabled, you will see separate model files for each run under *Outputs + logs*.
+    - You can also view the metrics for each job in the experiment under the *Metrics* tab.
+
+4. Upon completion, download the model files to your local machine using the script `get_mlflow_artifacts.py`. This script allows you to query your MLFlow registry on AzureML and download the top performing policy.
+    - In order to run this script, first create a [workspace configuration file](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-configure-environment?view=azureml-api-2#local-and-dsvm-only-create-a-workspace-configuration-file) in your local directory.
+
+## Next Steps
+Now that you understand how to use MLflow to log models, you can:
+- Optimize the hyperparameter tuning process with different search algorithms and spaces.
+- Evaluate your best performing model on new episodes or metrics.
+- Deploy your model to production or serve them on Azure.


### PR DESCRIPTION
# Description

Our examples currently have similar sections in the readme files, but they are not standardized. This PR modifies each example readme to follow this format:
```
# <Title>
### What this sample covers
### What this sample does not cover
## Prerequisites
## What is being "simulated"?
## Run Locally
## Tutorial: Run on AML
## Next Steps
```

## Type of change

- [x] This change is a documentation update

# Checklist:

- [x] I have squashed my previous commits into one commit and added a __meaningful__ commit message.
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
