### PR TITLE
Deploy agent overriding num rollout workers

### DIFF
--- a/examples/deploy-agent/src/serve.py
+++ b/examples/deploy-agent/src/serve.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import gymnasium.spaces as spaces
@@ -5,7 +6,7 @@ import numpy as np
 from ray import serve
 
 from platotk.restore import restore_agent_from_pickle
-from platotk.serialize import check_and_transform
+from platotk.serialize import GymEncoder, check_and_transform
 
 # The name of the folder where the checkpoints are located in the checkpoints/ folder
 # IMPORTANT: Remember to change it
@@ -50,7 +51,9 @@ class ServeAgent:
         state = check_and_transform(observation_space, json_input["state"])
         # Set explore to false or the agent will not be deterministic
         action = self.agent.compute_single_action(state, explore=False)
-        return action
+        # In order to properly format scalar as scalar and not as singleton-lists
+        action_formatted = json.loads(json.dumps(action, cls=GymEncoder))
+        return action_formatted
 
 
 agent = ServeAgent.bind()  # type: ignore

--- a/examples/deploy-agent/src/serve.py
+++ b/examples/deploy-agent/src/serve.py
@@ -4,7 +4,7 @@ import gymnasium.spaces as spaces
 import numpy as np
 from ray import serve
 
-from platotk.restore import restore_agent
+from platotk.restore import restore_agent_from_pickle
 from platotk.serialize import check_and_transform
 
 # The name of the folder where the checkpoints are located in the checkpoints/ folder
@@ -33,11 +33,19 @@ def prepare_path(checkpoint_folder):
 class ServeAgent:
     def __init__(self):
         check_path = prepare_path(CHECKPOINT_FOLDER)
-        self.agent = restore_agent(
+        self.check_path = check_path
+        self.agent = restore_agent_from_pickle(
             observation_space, action_space, check_path, name_env
         )
 
     async def __call__(self, request):
+        """
+        Respond with an action to a request containing a state.
+
+        The try-except block is needed because with ``ray==2.5.0`` the agent
+        restored from the pickle is None and computing single action does not
+        work. With this workaround we can support multiple ray's versions.
+        """
         json_input = await request.json()
         state = check_and_transform(observation_space, json_input["state"])
         # Set explore to false or the agent will not be deterministic

--- a/src/platotk/restore.py
+++ b/src/platotk/restore.py
@@ -1,3 +1,6 @@
+import pickle
+from pathlib import Path
+
 from gymnasium import Env
 from ray.rllib.algorithms.algorithm import Algorithm
 from ray.tune.registry import register_env
@@ -20,11 +23,37 @@ class DummyEnv(Env):
         return self.observation_space.sample(), {}
 
 
-def restore_agent(
+def restore_agent_from_checkpoint(
     observation_space,
     action_space,
     checkpoint_path,
     name_env="sim_env",
 ):
+    """Restore an RLlib agent using ``from_checkpoint``."""
     register_env(name_env, lambda conf: DummyEnv(conf, observation_space, action_space))
     return Algorithm.from_checkpoint(checkpoint_path)
+
+
+def restore_agent_from_pickle(
+    observation_space,
+    action_space,
+    checkpoint_path,
+    name_env="sim_env",
+):
+    """Restore an RLlib agent by unpickling and modifying config."""
+    with open(Path(checkpoint_path) / "algorithm_state.pkl", "rb") as fp:
+        data = pickle.load(fp)
+    agent_config = data["config"].copy(copy_frozen=False)
+    agent = (
+        agent_config.rollouts(
+            num_rollout_workers=0,
+        )
+        .environment(
+            env=None,
+            observation_space=observation_space,
+            action_space=action_space,
+        )
+        .build()
+    )
+    agent.restore(checkpoint_path)
+    return agent


### PR DESCRIPTION
# Description

Apparently when restoring an Algorithm using ``from_checkpoint``, Ray tries
to initialize the same number of workers used for training.
In order to avoid this, we re-implement the unpickle approach for restoring
the agent where we override the number of rollout workers in the Algorithm
config.
This issue was raised to the RLlib team: https://github.com/ray-project/ray/issues/36761

Also, the number of rollout workers is set to 0 to avoid the bug solved in
https://github.com/Azure/plato/commit/071fd69404700ff4f510ca158a7a2083f82fa21d.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Sample runs

# Checklist:

- [x] I have squashed my previous commits into one commit and added a __meaningful__ commit message.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
