### PR TITLE
Allow parallelization for Anylogic sample

### DIFF
--- a/examples/getting-started-anylogic-sim/README.md
+++ b/examples/getting-started-anylogic-sim/README.md
@@ -57,7 +57,9 @@ To do this:
 docker build -t anylogic-sim .
 ```
 
-2. Go back to the ``getting-started-anylogic-sim`` folder and run:
+2. In ``src/start.sh`` append ``--test-local`` to ``python -u main.py``
+
+3. Go back to the ``getting-started-anylogic-sim`` folder and run:
   ```bash
   docker run --rm -it -e LOG_LEVEL=debug -v $(pwd)/src:/opt/src anylogic-sim bash /opt/src/start.sh
   ```
@@ -81,16 +83,19 @@ train an RL agent on AML:
    and ``compute`` to be the same as those you created in the prerequisites
    section.
 
-2. Launch the job using the Azure CLI:
+2. Remember to remove ``--test-local`` from ``start.sh`` if you tested the
+   sample locally
+
+3. Launch the job using the Azure CLI:
 ```
 az ml job create -f job.yml --workspace-name $YOUR_WORKSPACE --resource-group $YOUR_RESOURCE_GROUP
 ```
 
-3. Check that it is running by finding the job you launched in [AML
+4. Check that it is running by finding the job you launched in [AML
    studio](https://ml.azure.com/). You should see that ``ray`` is writing
    logs in the *Outputs + logs* tab in the ``user_logs`` folder.
 
-4. Once the job is completed, the model checkpoints can also be found in AML
+5. Once the job is completed, the model checkpoints can also be found in AML
    studio under the *Outputs + Logs* tab of your job
    in the ``outputs`` folder.
 

--- a/examples/getting-started-anylogic-sim/src/sim.py
+++ b/examples/getting-started-anylogic-sim/src/sim.py
@@ -1,4 +1,7 @@
 import json
+import subprocess
+import time
+from pathlib import Path
 
 import requests
 from gymnasium import Env, spaces
@@ -26,6 +29,24 @@ class SimWrapper(Env):
             "arrivalRate": 0.5,
             "sizeBufferQueues": 45,
         }
+        self.start_anylogic_sim()
+
+    def start_anylogic_sim(self):
+        scripts = [script for script in Path(__file__).parent.rglob("*_linux.sh")]
+        if len(scripts) > 1:
+            raise RuntimeError(f"Too many Anylogic sims found: {scripts}")
+        elif len(scripts) < 1:
+            raise RuntimeError("No Anylogic sim found.")
+
+        sim_exec = scripts.pop()
+        penv = {
+            "SIM_API_HOST": "http://localhost:8000",
+            "SIM_CONTEXT": "{}",
+            "SIM_WORKSPACE": "dummy",
+            "SIM_ACCESS_KEY": "dummy",
+        }
+        subprocess.Popen([sim_exec], env=penv)
+        time.sleep(10)
 
     def reset(self, *, seed=None, options=None):
         log.debug("Reset send.")

--- a/examples/getting-started-anylogic-sim/src/sim.py
+++ b/examples/getting-started-anylogic-sim/src/sim.py
@@ -1,4 +1,5 @@
 import json
+import os
 import subprocess
 import time
 from pathlib import Path
@@ -9,12 +10,13 @@ from gymnasium import Env, spaces
 from platotk.logger import log
 from platotk.serialize import GymEncoder, check_and_transform
 
-BASE_URL = "http://localhost:8000"
-
 
 class SimWrapper(Env):
     def __init__(self, env_config):
-        self.base_url = BASE_URL
+        self.base_host = "localhost"
+        self.env_id = int(f"{env_config.worker_index}{env_config.vector_index}")
+        self.base_port = 8000 + self.env_id
+        self.base_url = f"http://{self.base_host}:{self.base_port}"
 
         self.action_space = spaces.Dict(
             {
@@ -29,24 +31,47 @@ class SimWrapper(Env):
             "arrivalRate": 0.5,
             "sizeBufferQueues": 45,
         }
-        self.start_anylogic_sim()
+        self.start_sim_framework()
 
-    def start_anylogic_sim(self):
+    @staticmethod
+    def find_unique_port(worker, vector):
+        return 8000 + int(f"{worker}{vector}")
+
+    def start_sim_framework(self):
+        """Start Baobab API and external sim."""
+
+        # Find the sim executable
         scripts = [script for script in Path(__file__).parent.rglob("*_linux.sh")]
         if len(scripts) > 1:
             raise RuntimeError(f"Too many Anylogic sims found: {scripts}")
         elif len(scripts) < 1:
             raise RuntimeError("No Anylogic sim found.")
-
         sim_exec = scripts.pop()
+
+        os.environ["BAOBAB_NAMESPACE"] = str(self.env_id)
+
+        # Launch Baobab
+        subprocess.Popen(
+            [
+                "gunicorn",
+                "--worker-class",
+                "uvicorn.workers.UvicornWorker",
+                "--bind",
+                f"{self.base_host}:{self.base_port}",
+                "platotk.baobab:app",
+            ]
+        )
+        time.sleep(2)
+
+        # Launch the sim that will connect to Baobab
         penv = {
-            "SIM_API_HOST": "http://localhost:8000",
+            "SIM_API_HOST": self.base_url,
             "SIM_CONTEXT": "{}",
             "SIM_WORKSPACE": "dummy",
             "SIM_ACCESS_KEY": "dummy",
         }
         subprocess.Popen([sim_exec], env=penv)
-        time.sleep(10)
+        time.sleep(5)
 
     def reset(self, *, seed=None, options=None):
         log.debug("Reset send.")

--- a/examples/getting-started-anylogic-sim/src/start.sh
+++ b/examples/getting-started-anylogic-sim/src/start.sh
@@ -2,9 +2,4 @@
 set -xe
 memcached -p 11211 -u memcache -l 127.0.0.1 -d
 
-gunicorn \
-	--worker-class uvicorn.workers.UvicornWorker \
-	--bind '127.0.0.1:8000' \
-	platotk.baobab:app &
-
 python -u main.py --test-local

--- a/examples/getting-started-anylogic-sim/src/start.sh
+++ b/examples/getting-started-anylogic-sim/src/start.sh
@@ -7,19 +7,4 @@ gunicorn \
 	--bind '127.0.0.1:8000' \
 	platotk.baobab:app &
 
-export SIM_API_HOST=http://localhost:8000
-export SIM_CONTEXT={}
-export SIM_WORKSPACE=dummy
-export SIM_ACCESS_KEY=dummy
-
-N_SIM="$(find -type f -name '*_linux.sh' 2> /dev/null | wc -l)"
-SIM_EXE="$(find -type f -name '*_linux.sh' 2> /dev/null)"
-if [ $N_SIM -gt 1 ]
-then
-	echo "More than one sim found:"
-	echo "$SIM_EXE"
-	exit 1
-fi
-
-bash "$SIM_EXE" &
 python -u main.py --test-local

--- a/examples/getting-started-anylogic-sim/src/start.sh
+++ b/examples/getting-started-anylogic-sim/src/start.sh
@@ -2,4 +2,4 @@
 set -xe
 memcached -p 11211 -u memcache -l 127.0.0.1 -d
 
-python -u main.py --test-local
+python -u main.py

--- a/src/platotk/baobab.py
+++ b/src/platotk/baobab.py
@@ -9,6 +9,7 @@ To test the API locally, first install ``platotk`` and then run
 
 """
 import asyncio
+import os
 import uuid
 
 from aiocache import Cache
@@ -16,8 +17,11 @@ from fastapi import FastAPI, Request
 
 from platotk.logger import log
 
+namespace = os.getenv("BAOBAB_NAMESPACE", "example")
+
+log.info("BAOBAB namespace: %s", namespace)
 app = FastAPI()
-cache = Cache(Cache.MEMCACHED, endpoint="localhost", port=11211, namespace="main")
+cache = Cache(Cache.MEMCACHED, endpoint="localhost", port=11211, namespace=namespace)
 
 
 class SimState:


### PR DESCRIPTION
# Description

This commits introduces proper handling of parallelization for Baobab simulations.
The earlier implementation did not allow running multiple simulation environments because there was only one instance of Baobab running, and that instance was not segregating information related
to the Anylogic sim -- Rllib sim environment.
This PR introduces two main things:

- It changes the way Baobab and Anylogic sim are instantiated. Before ``start.sh`` only instantiated 1 copy of each. Now, the ``sim.py`` connector launches them. This allows to launch as many Baobab and Anylogic sim as we have RLlib environments.
- Only one memcached instance remains, and each Baobab instance write in their own namespace for data segregation.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Run the sample to see that everything works. Try to play with the number of rollout workers to see that effectively training completes faster.

# Checklist:

- [x] I have squashed my previous commits into one commit and added a __meaningful__ commit message.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
